### PR TITLE
Skip map options and generate floating island world from main menu

### DIFF
--- a/mc/net/minecraft/client/GuiMainTitle.py
+++ b/mc/net/minecraft/client/GuiMainTitle.py
@@ -1,6 +1,5 @@
 from mc.net.minecraft.client.gui.GuiScreen import GuiScreen
 from mc.net.minecraft.client.gui.GuiOptions import GuiOptions
-from mc.net.minecraft.client.gui.GuiNewLevel import GuiNewLevel
 from mc.net.minecraft.client.gui.GuiLoadLevel import GuiLoadLevel
 from mc.net.minecraft.client.gui.GuiButton import GuiButton
 from mc.net.minecraft.client.render.Tessellator import tessellator
@@ -38,7 +37,10 @@ class GuiMainTitle(GuiScreen):
         if button.id == 0:
             self.mc.displayGuiScreen(GuiOptions(self, self.mc.options))
         elif button.id == 1:
-            self.mc.displayGuiScreen(GuiNewLevel(self))
+            # Directly generate a floating island world (size: Normal, shape: Square, theme: Normal)
+            self.mc.generateNewLevel(1, 0, 2, 0)
+            self.mc.displayGuiScreen(None)
+            self.mc.grabMouse()
         elif self.mc.session and button.id == 2:
             self.mc.displayGuiScreen(GuiLoadLevel(self))
 


### PR DESCRIPTION
## Summary
- Bypass map options screen and create a floating island world immediately when "Generate new level" is clicked.

## Testing
- `python -m py_compile mc/net/minecraft/client/GuiMainTitle.py mc/net/minecraft/client/Minecraft.py`


------
https://chatgpt.com/codex/tasks/task_e_6892ae9c8f94832293813b82634c2a62