### PR TITLE
Add missing TNT renderer

### DIFF
--- a/mc/net/minecraft/client/render/entity/RenderTNTPrimed.py
+++ b/mc/net/minecraft/client/render/entity/RenderTNTPrimed.py
@@ -1,0 +1,32 @@
+from mc.net.minecraft.client.render.entity.Render import Render
+from mc.net.minecraft.client.render.RenderBlocks import RenderBlocks
+from mc.net.minecraft.client.render.Tessellator import tessellator
+from mc.net.minecraft.game.level.block.Blocks import blocks
+from pyglet import gl
+
+
+class RenderTNTPrimed(Render):
+    """Simple renderer for primed TNT entities.
+
+    The original project expected a dedicated renderer for the TNT entity
+    but the module was missing which prevented the game from starting due to
+    an import failure inside ``RenderManager``.  This implementation mirrors
+    the behaviour of other renderers by using ``RenderBlocks`` to draw a block
+    model.  If a specific TNT block is unavailable in ``Blocks`` we fall back
+    to rendering cobblestone so that the entity can still be displayed and the
+    import succeeds.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._shadowSize = 0.5
+        self.__renderBlocks = RenderBlocks(tessellator)
+
+    def doRender(self, entity, xd, yd, zd, yaw, a):
+        gl.glPushMatrix()
+        gl.glTranslatef(xd, yd, zd)
+        self._loadTexture('terrain.png')
+        # Use TNT block if available, otherwise fall back to cobblestone
+        block = getattr(blocks, 'tnt', None) or blocks.cobblestone
+        self.__renderBlocks.renderBlockOnInventory(block)
+        gl.glPopMatrix()


### PR DESCRIPTION
## Summary
- add missing renderer for primed TNT entities to prevent startup crash

## Testing
- `pytest`
- `python -m mc.net.minecraft.client.Minecraft` *(fails: No module named 'pyglet')*
- `pip install pyglet` *(fails: Could not find a version that satisfies the requirement pyglet (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_6892fc138b7c83228af83d55e5c3a4cc