### PR TITLE
Add powder footstep sound alias

### DIFF
--- a/mc/net/minecraft/game/level/block/Blocks.py
+++ b/mc/net/minecraft/game/level/block/Blocks.py
@@ -20,6 +20,7 @@ class Blocks:
         self.soundWood = StepSound('wood', 1.0, 1.0)
         self.soundGrass = StepSound('grass', 1.0, 1.0)
         self.soundStone = StepSound('stone', 1.0, 1.0)
+        self.soundPowderFootstep = self.soundStone
 
         self.stone = BlockStone(self, 1, 1).setHardness(1.0).setResistance(10.0)
         self.stone.stepSound = self.soundStone


### PR DESCRIPTION
## Summary
- add `soundPowderFootstep` alias to `Blocks` to satisfy runtime references

## Testing
- `python setup.py build_ext --inplace`
- `python -m mc.net.minecraft.client.Minecraft` (terminated with KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68946f432bc08322908a1218fe1f8d66