### PR TITLE
Check for EGL before enabling headless mode

### DIFF
--- a/mc/net/minecraft/client/Minecraft.py
+++ b/mc/net/minecraft/client/Minecraft.py
@@ -1,10 +1,13 @@
 import pyglet
 import platform
 import os
+import ctypes.util
+
 pyglet.options['debug_gl'] = False
 pyglet.options['search_local_libs'] = True
 pyglet.options['audio'] = ('openal', 'silent')
-pyglet.options['headless'] = True
+if ctypes.util.find_library('EGL'):
+    pyglet.options['headless'] = True
 
 if pyglet.compat_platform == 'win32':
     os.environ['PATH'] += os.pathsep + os.path.join(os.getcwd(), 'mc', 'lib')


### PR DESCRIPTION
## Summary
- Enable Pyglet headless mode only when an EGL library is available

## Testing
- `python -m mc.net.minecraft.client.Minecraft -h` *(ModuleNotFoundError, but no EGL error)*
- `python -m py_compile mc/net/minecraft/client/Minecraft.py`


------
https://chatgpt.com/codex/tasks/task_e_6894758448c08322ab4eb39aed3c5b9a