### PR TITLE
Add missing EntityBubbleFX stub

### DIFF
--- a/mc/net/minecraft/client/effect/EntityBubbleFX.py
+++ b/mc/net/minecraft/client/effect/EntityBubbleFX.py
@@ -1,0 +1,19 @@
+from mc.net.minecraft.client.effect.EntityFX import EntityFX
+
+
+class EntityBubbleFX(EntityFX):
+    """Minimal placeholder bubble particle effect.
+
+    The original game includes a bubble effect particle. The current project
+    does not implement it, but some modules still attempt to import the
+    class.  Providing this stub ensures those imports succeed while having no
+    behaviour."""
+
+    def __init__(self, world, x, y, z):
+        super().__init__(world, x, y, z, 0.0, 0.0, 0.0)
+
+    def renderParticle(self, t, a, xa, ya, za, xa2, ya2):
+        """Render the particle. This stub intentionally does nothing."""
+
+    def onEntityUpdate(self):
+        """Update the particle each tick. This stub intentionally does nothing."""


### PR DESCRIPTION
## Summary
- add minimal `EntityBubbleFX` implementation so `RenderGlobal` import resolves

## Testing
- `python setup.py build_ext --inplace`
- `python -m mc.net.minecraft.client.Minecraft` *(interrupted after main menu render)*

------
https://chatgpt.com/codex/tasks/task_e_689499192b0c83228bb3f47127c1cc03