### PR TITLE
Fix missing fire block reference

### DIFF
--- a/mc/net/minecraft/game/level/block/BlockFire.py
+++ b/mc/net/minecraft/game/level/block/BlockFire.py
@@ -1,0 +1,22 @@
+from mc.net.minecraft.game.level.block.Block import Block
+
+
+class BlockFire(Block):
+    """Minimal stand-in for the original ``BlockFire`` implementation.
+
+    The project only uses the block as a reference for locating the fire
+    texture in the terrain atlas.  The real game contains extensive logic
+    for spreading and extinguishing fire which isn't needed for rendering
+    the title screen, so this class intentionally keeps behaviour to the
+    bare minimum required by the rest of the code base.
+    """
+
+    def __init__(self, blocks, block_id=51, tex=15):
+        super().__init__(blocks, block_id, tex)
+
+    # Fire is a non-solid block that shouldn't render like normal cubes.
+    def isOpaqueCube(self):
+        return False
+
+    def renderAsNormalBlock(self):
+        return False

--- a/mc/net/minecraft/game/level/block/Blocks.py
+++ b/mc/net/minecraft/game/level/block/Blocks.py
@@ -3,6 +3,7 @@ from mc.net.minecraft.game.level.block.BlockGrass import BlockGrass
 from mc.net.minecraft.game.level.block.BlockDirt import BlockDirt
 from mc.net.minecraft.game.level.block.BlockLog import BlockLog
 from mc.net.minecraft.game.level.block.BlockStone import BlockStone
+from mc.net.minecraft.game.level.block.BlockFire import BlockFire
 from mc.net.minecraft.game.level.block.StepSound import StepSound
 
 
@@ -39,6 +40,12 @@ class Blocks:
 
         self.wood = BlockLog(self, 17).setHardness(2.5)
         self.wood.stepSound = self.soundWood
+
+        # Placeholder fire block so texture effects can look up its texture
+        # index.  The original game contains far more complex fire behaviour,
+        # but for this project we only require the block to exist.
+        self.fire = BlockFire(self)
+        self.fire.stepSound = self.soundPowderFootstep
 
 
 blocks = Blocks()


### PR DESCRIPTION
## Summary
- provide minimal BlockFire implementation
- register fire block to satisfy texture lookup

## Testing
- `python setup.py build_ext --inplace`
- `python -m mc.net.minecraft.client.Minecraft` *(interrupted with KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6894a649b3648322a9cf2fa109a9cf32