### PR TITLE
Fix BlockFire initialization for Cython compatibility

### DIFF
--- a/mc/net/minecraft/game/level/block/Blocks.py
+++ b/mc/net/minecraft/game/level/block/Blocks.py
@@ -43,8 +43,11 @@ class Blocks:
 
         # Placeholder fire block so texture effects can look up its texture
         # index.  The original game contains far more complex fire behaviour,
-        # but for this project we only require the block to exist.
-        self.fire = BlockFire(self)
+        # but for this project we only require the block to exist.  The Cython
+        # implementation of ``BlockFire`` expects explicit ``block_id`` and
+        # ``tex`` parameters, so pass the default values to remain compatible
+        # with both the Python and compiled versions.
+        self.fire = BlockFire(self, 51, 15)
         self.fire.stepSound = self.soundPowderFootstep
 
 


### PR DESCRIPTION
## Summary
- ensure fire block is created with explicit block ID and texture index

## Testing
- `python -m py_compile mc/net/minecraft/game/level/block/Blocks.py`
- `python - <<'PY'
from mc.net.minecraft.game.level.block.Blocks import Blocks
b=Blocks()
print('fire id', b.fire.blockID, 'tex', b.fire.blockIndexInTexture)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894b4e4d0f48322a6931b8bf6cdabfa